### PR TITLE
RM-48625 Release barometer v0.1.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.workiva/barometer "0.1.0"
+(defproject com.workiva/barometer "0.1.1"
   :description "A thin wrapper over Coda Hale's metrics library for the JVM"
   :url "https://github.com/Workiva/barometer"
   :license {:name "Apache License, Version 2.0"}


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Bump dependency recide 1.0.0 -> 1.0.1](https://github.com/Workiva/barometer/pull/6)


Requested by: @tylerwilding-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/barometer/compare/v0.1.0...Workiva:release_barometer_v0.1.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/barometer/compare/v0.1.0...v0.1.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5338675764527104/logs/)