### PR TITLE
RM-48863 Release barometer v0.1.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.workiva/barometer "0.1.1"
+(defproject com.workiva/barometer "0.1.2"
   :description "A thin wrapper over Coda Hale's metrics library for the JVM"
   :url "https://github.com/Workiva/barometer"
   :license {:name "Apache License, Version 2.0"}


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [EVA-982 Add Github Pages documentation to barometer](https://github.com/Workiva/barometer/pull/5)
	* [Updating morphe dependency to latest and greatest](https://github.com/Workiva/barometer/pull/8)


Requested by: @aleksandrfurmanov-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/barometer/compare/v0.1.1...Workiva:release_barometer_v0.1.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/barometer/compare/v0.1.1...v0.1.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5338675764527104/logs/)